### PR TITLE
make `brew audit --strict` happy

### DIFF
--- a/dvrescue.rb
+++ b/dvrescue.rb
@@ -1,8 +1,7 @@
 class Dvrescue < Formula
-  desc "Data migration from DV tapes into digital files suitable for long-term preservation"
+  desc "Data migration from DV tapes into files for long-term preservation"
   homepage "https://mediaarea.net/dvrescue"
   url "https://mediaarea.net/download/snapshots/binary/dvrescue/20191114/dvrescue_CLI_0.19.11.20191114_GNU_FromSource.tar.xz"
-  version "0.19.11.20191114"
   sha256 "4bc15176157501f41f8c5a90c37b93c0ea1c6c8680bfee8fddb5d7b3fa251cb8"
 
   def install


### PR DESCRIPTION
- Description is too long. "name: desc" should be less than 80 characters. Length is calculated as dvrescue + desc. (currently 93)
- Stable: version 0.19.11.20191114 is redundant with version scanned from URL