### PR TITLE
make `brew audit --strict` happy

### DIFF
--- a/rawcooked.rb
+++ b/rawcooked.rb
@@ -2,7 +2,6 @@ class Rawcooked < Formula
   desc "Lossless RAW audio-visual data to MKV encoder and decoder"
   homepage "https://mediaarea.net/RAWcooked"
   url "https://mediaarea.net/download/binary/rawcooked/18.10.1/RAWcooked_CLI_18.10.1_GNU_FromSource.tar.xz"
-  version "18.10.1"
   sha256 "4c0a090a0bec13ac70ef5eebfeed3d6b228f47d90068ec6cd4ca991944b5d3a3"
 
   def install


### PR DESCRIPTION
- Stable: version 18.10.1 is redundant with version scanned from URL