### PR TITLE
dvrescue: make `brew audit --strict`happy

### DIFF
--- a/dvrescue.rb
+++ b/dvrescue.rb
@@ -1,5 +1,5 @@
 class Dvrescue < Formula
-  desc "Data migration from DV tapes into digital files suitable for long-term preservation"
+  desc "Data migration from DV tapes into files for long-term preservation"
   homepage "https://mediaarea.net/dvrescue"
   url "https://mediaarea.net/download/binary/dvrescue/0.20.05/dvrescue_CLI_0.20.05_GNU_FromSource.tar.xz"
   sha256 "69cbf2c9f04548cdb950e3442eb498a801c1ddc689fa10895ecd3a44923efb45"


### PR DESCRIPTION
Currently it gives the error message:
“Description is too long. "name: desc" should be less than 80 characters. Length is calculated as dvrescue + desc. (currently 93)”