### PR TITLE
mediainfo-gui, dvrescue: replace include in ZenLib

### DIFF
--- a/dvrescue.rb
+++ b/dvrescue.rb
@@ -6,6 +6,8 @@ class Dvrescue < Formula
 
   depends_on "xmlstarlet"
 
+  patch :DATA
+
   def install
     cd "ZenLib/Project/GNU/Library" do
       args = ["--disable-debug",
@@ -34,6 +36,21 @@ class Dvrescue < Formula
   end
 
   test do
-    system "#{bin}/dvrescue", "--help"
+    system "bin/dvrescue", "--help"
   end
 end
+
+__END__
+diff --git a/ZenLib/Source/ZenLib/Conf.h b/ZenLib/Source/ZenLib/Conf.h
+index 792f313..735aa33 100644
+--- a/ZenLib/Source/ZenLib/Conf.h
++++ b/ZenLib/Source/ZenLib/Conf.h
+@@ -208,7 +208,7 @@
+ //---------------------------------------------------------------------------
+ //(-1) is known to be the MAX of an unsigned int but GCC complains about it
+ #ifdef __cplusplus
+-    #include <new> //for size_t
++    #include <cstddef> //for size_t
+ #else /* __cplusplus */
+     #include <stddef.h> //for size_t
+ #endif /* __cplusplus */

--- a/mediainfo-gui.rb
+++ b/mediainfo-gui.rb
@@ -9,6 +9,8 @@ class MediainfoGui < Formula
   depends_on "curl"
   depends_on "wxwidgets"
 
+  patch :DATA
+
   def install
     cd "ZenLib/Project/GNU/Library" do
       args = ["--disable-debug",
@@ -37,3 +39,18 @@ class MediainfoGui < Formula
     assert_predicate `bin/mediainfo-gui`, :exist?
   end
 end
+
+__END__
+diff --git a/ZenLib/Source/ZenLib/Conf.h b/ZenLib/Source/ZenLib/Conf.h
+index 792f313..735aa33 100644
+--- a/ZenLib/Source/ZenLib/Conf.h
++++ b/ZenLib/Source/ZenLib/Conf.h
+@@ -208,7 +208,7 @@
+ //---------------------------------------------------------------------------
+ //(-1) is known to be the MAX of an unsigned int but GCC complains about it
+ #ifdef __cplusplus
+-    #include <new> //for size_t
++    #include <cstddef> //for size_t
+ #else /* __cplusplus */
+     #include <stddef.h> //for size_t
+ #endif /* __cplusplus */


### PR DESCRIPTION
Fixes mipops/dvrescue#942