### PR TITLE
Remove macOS High Sierra dependency from dvrescue-gui

### DIFF
--- a/Casks/dvrescue-gui.rb
+++ b/Casks/dvrescue-gui.rb
@@ -12,8 +12,6 @@ cask "dvrescue-gui" do
     regex(/href=.*?dvrescue_GUI_(\d+(?:\.\d+)+)_Mac\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "DVRescue.app"
 
   zap trash: [


### PR DESCRIPTION
Calling `depends_on macos: :high_sierra` has been disabled by Homebrew.