### PR TITLE
Remove `depends_on macos: :high_sierra` from MediaConch GUI

### DIFF
--- a/Casks/mediaconch-gui.rb
+++ b/Casks/mediaconch-gui.rb
@@ -12,8 +12,6 @@ cask "mediaconch-gui" do
     regex(/href=.*?MediaConch_GUI_(\d+(?:\.\d+)+)_Mac\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "MediaConch.app"
 
   zap trash: [


### PR DESCRIPTION
It has been disabled by Homebrew. Same issue as https://github.com/MediaArea/homebrew-mediaarea/pull/144.